### PR TITLE
chore(ci): add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test -- --run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "make-bookmarklet",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "make-bookmarklet",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-bookmarklet",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Node program to convert small JavaScript files to bookmarklet-ready code.",
   "type": "module",
   "main": "src/make-bookmarklet.js",

--- a/src/__tests__/cli.spec.js
+++ b/src/__tests__/cli.spec.js
@@ -1,7 +1,7 @@
-import { test, expect } from 'vitest';
+import { execa } from 'execa';
 import fs from 'fs';
 import path from 'path';
-import { execa } from 'execa';
+import { test, expect } from 'vitest';
 
 const fixturePath = path.join('src', '__tests__', '__fixtures__', 'input', 'whitespace.js');
 
@@ -36,16 +36,16 @@ test('unmake-bookmarklet reads from stdin when piped', async () => {
 test('unmake-bookmarklet runs with relative path and file argument', async () => {
   const { stdout } = await execa('node', ['src/unmake-bookmarklet.js', 'examples/bookmarklets/b1.js']);
   // When run non-interactively (captured stdout), CLI prints the formatted code; assert content is present
-  expect(stdout).toContain("earningsList_rppDD");
+  expect(stdout).toContain('earningsList_rppDD');
 });
 
 test('unmake-bookmarklet runs with ./src path', async () => {
   const { stdout } = await execa('node', ['./src/unmake-bookmarklet.js', 'examples/bookmarklets/b1.js']);
-  expect(stdout).toContain("earningsList_rppDD");
+  expect(stdout).toContain('earningsList_rppDD');
 });
 
 test('unmake-bookmarklet runs with absolute script path', async () => {
   const script = path.resolve('src/unmake-bookmarklet.js');
   const { stdout } = await execa('node', [script, 'examples/bookmarklets/b1.js']);
-  expect(stdout).toContain("earningsList_rppDD");
+  expect(stdout).toContain('earningsList_rppDD');
 });

--- a/src/__tests__/unmake-bookmarklet.spec.js
+++ b/src/__tests__/unmake-bookmarklet.spec.js
@@ -1,9 +1,9 @@
-import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import clipboardy from 'clipboardy';
 import fs from 'fs';
 import path from 'path';
-import prettier from 'prettier';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+
 import unmakeBookmarklet from '../unmake-bookmarklet.js';
-import clipboardy from 'clipboardy';
 import { withTempDirAsync } from './utils/tempDir.js';
 
 // Mock clipboardy globally for these tests
@@ -44,7 +44,7 @@ test('prettier throwing sets non-zero exit and logs error', async () => {
   // Cause decodeURIComponent to throw by writing invalid percent-encoding
   await withTempDirAsync(async (tmpDir) => {
     const tmp = path.join(tmpDir, 'bm.js');
-    fs.writeFileSync(tmp, `javascript:%E0`);
+    fs.writeFileSync(tmp, 'javascript:%E0');
     const origArgv = process.argv;
     process.argv = ['node', 'src/unmake-bookmarklet.js', tmp];
 


### PR DESCRIPTION
Add GitHub Actions CI to run lint and tests on pushes and PRs to main.

This workflow ensures that new contributions run semistandard linting and the Vitest test suite on Node 20.x.