### PR TITLE
chore(release): add semantic-release CI release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   test:
     name: Lint & Test
@@ -31,3 +35,30 @@ jobs:
 
       - name: Run tests
         run: npm test -- --run
+
+  release:
+    name: Release
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install semantic-release and plugins
+        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/github
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,12 @@ jobs:
         run: npm ci
 
       - name: Install semantic-release and plugins
-        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/github
+        run: npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github
+
+      - name: Configure git for release commits
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run semantic-release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,9 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    "@semantic-release/github"
+  ]
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,6 +4,7 @@
     ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
     "@semantic-release/release-notes-generator",
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/git", { "assets": ["CHANGELOG.md"], "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}" }],
     "@semantic-release/github"
   ]
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,7 @@ Testing & rollout:
 
 ```bash
 # Manual install + dry-run
-npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/github
+npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github
 npx semantic-release --dry-run
 
 # Convenience script (recommended for maintainers)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,7 +41,18 @@ Files & configuration:
 
 Testing & rollout:
 
-- To validate behavior locally or in a branch, run: `npx semantic-release --dry-run` (this will print the decisions without making changes).
+- To validate behavior locally or in a branch, first install `semantic-release` and the required plugins temporarily (they are installed in CI by the workflow), or use the convenience npm script added to this repo:
+
+```bash
+# Manual install + dry-run
+npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/github
+npx semantic-release --dry-run
+
+# Convenience script (recommended for maintainers)
+npm run release:dry-run
+```
+
+- Note: `semantic-release` loads plugins from your environment, so running `npx semantic-release` without the plugins installed will cause a `MODULE_NOT_FOUND` error (e.g., `Cannot find module '@semantic-release/changelog'`). In CI we install the plugins at runtime to avoid adding them as dev dependencies.
 - Monitor the first automated release to verify the GitHub release notes and tags are created as expected.
 
 Further considerations:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,7 +57,7 @@ npm run release:dry-run
 
 Further considerations:
 
-- If you want `CHANGELOG.md` committed back to the repo, add `@semantic-release/git` to the plugin list — be careful to avoid CI loops when committing from the workflow.
+- We commit `CHANGELOG.md` automatically using `@semantic-release/git`. The release commit message includes `[skip ci]` to avoid triggering another release workflow run and creating a CI loop.
 - When you're ready to publish to npm, add `@semantic-release/npm` and configure an `NPM_TOKEN` repository secret; update the release job to provide `NPM_TOKEN` to the environment.
 - Consider enforcing Conventional Commits with `commitlint` + `husky` or a CI check to ensure reliable release behavior.
 - Update contributor docs to encourage Conventional Commit style for commit messages.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "lint": "semistandard",
     "lint:fix": "semistandard --fix",
-    "test": "vitest"
+    "test": "vitest",
+    "release:dry-run": "npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/github && npx semantic-release --dry-run"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "semistandard",
     "lint:fix": "semistandard --fix",
     "test": "vitest",
-    "release:dry-run": "npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/github && npx semantic-release --dry-run"
+    "release:dry-run": "npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github && npx semantic-release --dry-run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary 
Add CI-driven, runtime-installed semantic-release automation to create GitHub releases and update CHANGELOG.md 

## What changed 
- **Added** .releaserc.json (Conventional Commits + plugins: commit-analyzer, release-notes-generator, changelog, git, github)  
- **Updated** ci.yml:
  - added `permissions: contents: write, packages: write`
  - added `release` job (runs only on pushes to `main`, depends on `test`)
  - installs `semantic-release` + plugins at runtime and runs `npx semantic-release@latest`
  - configures git author and uses `fetch-depth: 0` so release commits/tags work
- **Updated** DEVELOPMENT.md with usage and testing notes
- **Added** `release:dry-run` npm script to help maintainers run a local dry-run

## Behavior after merge 
- On merge/push to `main`, CI runs `test` job; if tests pass the `release` job runs.  
- `semantic-release` will:
  - create GitHub Release + tag,
  - update CHANGELOG.md and commit it using `@semantic-release/git` (commit message includes `[skip ci]` to avoid workflow loops).  
- **No npm publishing** (no `@semantic-release/npm` and no `NPM_TOKEN`) — can be added later.

## How to test locally 
- Recommended: run the convenience script (installs plugins temporarily and does a dry-run):
  - `npm run release:dry-run`

## Reviewer checklist 
- [ ] Review .releaserc.json and plugin list for desired behavior (esp. `@semantic-release/git` config).  
- [ ] Optionally run `npm run release:dry-run` locally.  
- [ ] Merge when ready to trigger a real CI release (tests must pass; release job runs only on `main`).  
- [ ] After merge, verify GitHub Actions run and confirm a Release/tag/CHANGELOG commit appears as expected.

## Notes & rollback 
- The CHANGELOG.md commit includes `[skip ci]` to prevent CI loops.  
- If a release is created by mistake you can delete the Release and tag on GitHub, or revert the release commit locally and push a revert. I can assist with rollback steps if needed.
- Suggest follow-ups: add commit message enforcement (`commitlint` + `husky`) and add npm publishing (`@semantic-release/npm`) when ready.