### PR TITLE
chore(ci): install conventional-changelog-conventionalcommits for release-notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,13 @@ jobs:
         run: npm ci
 
       - name: Install semantic-release and plugins
-        run: npm install --no-save semantic-release@25 @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github
+        run: npm install --no-save semantic-release@25 \
+          @semantic-release/commit-analyzer \
+          @semantic-release/release-notes-generator \
+          @semantic-release/changelog \
+          @semantic-release/git \
+          @semantic-release/github \
+          conventional-changelog-conventionalcommits
 
       - name: Configure git for release commits
         run: |

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "semistandard",
     "lint:fix": "semistandard --fix",
     "test": "vitest",
-    "release:dry-run": "npm install --no-save semantic-release@25 @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github && npx semantic-release@25 --dry-run"
+    "release:dry-run": "npm install --no-save semantic-release@25 @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github conventional-changelog-conventionalcommits && npx semantic-release@25 --dry-run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix CI release failure by installing the Conventional Commits preset package required by the release-notes generator.

- Adds  to the CI runtime install step and the  script for parity.
- Verify locally with `npm run release:dry-run` and verify CI by running the workflow on the branch or merging after review.