### PR TITLE
chore: upgrade GitHub Actions to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -42,14 +42,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
           persist-credentials: true
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.x"
 


### PR DESCRIPTION
### Summary

This PR updates GitHub Actions versions in the CI workflow to current majors:

- `actions/checkout`: `v4` -> `v5`
- `actions/setup-node`: `v4` -> `v5`

Applied in both `test` and `release` jobs.

### Why
Recent workflow runs reported deprecation warnings for JavaScript actions running on Node 20. Upgrading to v5 aligns with upcoming GitHub Actions runtime defaults and reduces future CI risk.

### Scope
- File changed: ci.yml
- No changes to release logic, branch conditions, or semantic-release behavior.

(Written by CoPilot, copy/pasted by me.)