### PR TITLE
chore: split release dry-run scripts and fix audit vulnerabilities

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,8 @@ This document is for maintainers and contributors (internal notes).
 - Lint: `npm run lint:md`
 - Fix markdownlint issues: `npm run lint:md:fix`
 - Test: `npm test -- --run`
-- Dry-run release: `npm run release:dry-run` (verifies semantic-release decisions)
+- Dry-run release (main branch, CI-like): `npm run release:dry-run:main`
+- Dry-run release (feature branch prediction): `npm run release:dry-run:feature`
 - Push branch, open a PR against `main`, get 1 approval and wait for checks to pass
 - Merge PR to `main` (CI runs tests, then release job if a release is needed)
 - Verify: check Actions, GitHub Releases, tags, and `CHANGELOG.md`
@@ -64,13 +65,17 @@ Testing & rollout:
 npm install --no-save semantic-release @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github
 GITHUB_TOKEN="$RELEASE_PAT" npx semantic-release --dry-run
 
-# Convenience script (recommended for maintainers)
+# Convenience scripts (recommended for maintainers)
 npm run release:dry-run
+npm run release:dry-run:main
+npm run release:dry-run:feature
 ```
 
 - Note: `semantic-release` loads plugins from your environment, so running `npx semantic-release` without the plugins installed will cause a `MODULE_NOT_FOUND` error (e.g., `Cannot find module '@semantic-release/changelog'`). In CI we install the plugins at runtime to avoid adding them as dev dependencies.
-- Note: `semantic-release` reads `GITHUB_TOKEN` or `GH_TOKEN`, so the convenience script maps `RELEASE_PAT` into those names for local dry-runs. If you run the manual command, export `GITHUB_TOKEN` yourself or prefix it as shown above.
-- We pin the semantic-release major in CI and the convenience script (e.g., `semantic-release@25`) to avoid unexpected breaking changes from a future major release. Update the pinned major intentionally when you want to upgrade and verify with `npm run release:dry-run`.
+- Note: `release:dry-run:main` mirrors CI behavior and requires local auth for `@semantic-release/github`. It maps `RELEASE_PAT` to `GITHUB_TOKEN`/`GH_TOKEN` automatically, but one of those variables must be set.
+- Note: `release:dry-run:feature` is intentionally token-free and performs local commit analysis (Conventional Commits) to estimate release impact from a feature branch before opening/merging a PR.
+- Implementation note: release dry-run command logic lives in `scripts/release-dry-run-main.sh`, `scripts/release-dry-run-feature.sh`, and `scripts/release-dry-run-feature.mjs` to keep `package.json` scripts short and maintainable.
+- We pin the semantic-release major in CI and convenience scripts (e.g., `semantic-release@25`) to avoid unexpected breaking changes from a future major release. Update the pinned major intentionally when you want to upgrade and verify with `npm run release:dry-run:main`.
 - Monitor the first automated release to verify the GitHub release notes and tags are created as expected.
 
 Further considerations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1022,9 +1022,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2404,9 +2404,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4691,9 +4691,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint:md": "markdownlint .",
     "lint:md:fix": "markdownlint --fix .",
     "test": "vitest",
-    "release:dry-run": "npm install --no-save semantic-release@25 @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github conventional-changelog-conventionalcommits && GITHUB_TOKEN=${GITHUB_TOKEN:-${RELEASE_PAT:-$GH_TOKEN}} GH_TOKEN=${GH_TOKEN:-${GITHUB_TOKEN:-$RELEASE_PAT}} npx semantic-release@25 --dry-run"
+    "release:dry-run": "npm run release:dry-run:main",
+    "release:dry-run:main": "sh ./scripts/release-dry-run-main.sh",
+    "release:dry-run:feature": "sh ./scripts/release-dry-run-feature.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/release-dry-run-feature.mjs
+++ b/scripts/release-dry-run-feature.mjs
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import semver from 'semver';
+
+const require = createRequire(import.meta.url);
+const { analyzeCommits } = require('@semantic-release/commit-analyzer');
+
+function run (cmd) {
+  return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function getLastTag () {
+  try {
+    return run('git describe --tags --abbrev=0');
+  } catch {
+    return null;
+  }
+}
+
+function getCommits (range) {
+  const format = '%H%x1f%B%x1e';
+  const output = run(`git log ${range} --pretty=format:${format}`);
+
+  if (!output) return [];
+
+  return output
+    .split('\x1e')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [hash, ...messageParts] = entry.split('\x1f');
+      return {
+        hash,
+        message: messageParts.join('\x1f').trim()
+      };
+    })
+    .filter((commit) => commit.message.length > 0);
+}
+
+function getCurrentVersion () {
+  const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+  return pkg.version;
+}
+
+const lastTag = getLastTag();
+const range = lastTag ? `${lastTag}..HEAD` : 'HEAD';
+const commits = getCommits(range);
+const currentVersion = getCurrentVersion();
+
+if (commits.length === 0) {
+  console.log('No commits found in range; no release expected.');
+  process.exit(0);
+}
+
+const releaseType = await analyzeCommits(
+  { preset: 'conventionalcommits' },
+  {
+    commits,
+    logger: {
+      log: () => { },
+      error: () => { }
+    }
+  }
+);
+
+if (!releaseType) {
+  console.log('Prediction: no new release (no release-worthy commits).');
+  process.exit(0);
+}
+
+const nextVersion = semver.valid(currentVersion) ? semver.inc(currentVersion, releaseType) : null;
+
+if (nextVersion) {
+  console.log(`Prediction: ${releaseType} release (from ${currentVersion} to ${nextVersion}).`);
+} else {
+  console.log(`Prediction: ${releaseType} release.`);
+}
+
+console.log(lastTag ? `Analyzed commits since ${lastTag}.` : 'Analyzed full commit history (no tag found).');

--- a/scripts/release-dry-run-feature.sh
+++ b/scripts/release-dry-run-feature.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+
+npm install --no-save \
+  semantic-release@25 \
+  @semantic-release/commit-analyzer \
+  conventional-changelog-conventionalcommits \
+  semver
+
+node ./scripts/release-dry-run-feature.mjs

--- a/scripts/release-dry-run-main.sh
+++ b/scripts/release-dry-run-main.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
+  echo "release:dry-run:main must be run on main."
+  exit 1
+fi
+
+npm install --no-save \
+  semantic-release@25 \
+  @semantic-release/commit-analyzer \
+  @semantic-release/release-notes-generator \
+  @semantic-release/changelog \
+  @semantic-release/git \
+  @semantic-release/github \
+  conventional-changelog-conventionalcommits
+
+GITHUB_TOKEN="${GITHUB_TOKEN:-${RELEASE_PAT:-${GH_TOKEN:-}}}"
+GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-${RELEASE_PAT:-}}}"
+
+if [ -z "${GITHUB_TOKEN}" ]; then
+  echo "Missing token: set RELEASE_PAT (or GITHUB_TOKEN/GH_TOKEN) before running release:dry-run:main."
+  exit 1
+fi
+
+export GITHUB_TOKEN
+export GH_TOKEN
+
+npx semantic-release@25 --dry-run


### PR DESCRIPTION
### Summary
Split dry-run script into two commands. 
Also apply `npm audit fix` lockfile updates.

### Changes
- Add `release-dry-run-main.sh` (CI-like main branch dry-run with token check)
- Add `release-dry-run-feature.sh` + `release-dry-run-feature.mjs` (token-free feature prediction)
- Update `package-lock.json` from `npm audit fix`

### Why
- Clearer expectations: feature-branch prediction vs main-branch validation

### Notes
Includes `fix(deps): remediate npm audit vulnerabilities`, which should trigger a patch bump under Conventional Commits.

(Written by CoPilot, edited by me.)